### PR TITLE
Use dummy scratch buffer to store DAP results

### DIFF
--- a/lua/codecompanion/_extensions/dap/scratch_buf.lua
+++ b/lua/codecompanion/_extensions/dap/scratch_buf.lua
@@ -39,7 +39,7 @@ end
 ---@return string
 function ScratchBufManager:get_readable_bufname(session)
   self:get_bufnr(session)
-  return string.format("%s %d", self.bufname_prefix, session.id)
+  return string.format("%s (session %d)", self.bufname_prefix, session.id)
 end
 
 ---@param session dap.Session
@@ -57,10 +57,6 @@ end
 ---@param chat CodeCompanion.Chat
 ---@param content string[]
 function ScratchBufManager:update(dap_session, chat, content)
-  if content == nil or vim.tbl_isempty(content) then
-    return
-  end
-
   local bufnr = self:get_bufnr(dap_session)
   local buf_name = self:get_readable_bufname(dap_session)
 

--- a/lua/codecompanion/_extensions/dap/scratch_buf.lua
+++ b/lua/codecompanion/_extensions/dap/scratch_buf.lua
@@ -1,0 +1,90 @@
+---@module "codecompanion"
+---@module "dap"
+
+---@class CodeCompanionDap.ScratchBufManager.InitOpts
+---@field bufname_prefix string
+---@field listed boolean?
+---Message prefixed to the scratch buffer
+---@field prefix string?
+
+---Creates and manages scratch buffer created by DAP requests.
+---These scratch buffers will contain the DAP results and monitored by Watcher.
+---@class CodeCompanionDap.ScratchBufManager: CodeCompanionDap.ScratchBufManager.InitOpts
+---Maps session ID to bufnr
+---@field session_to_buf table<integer, integer>
+local ScratchBufManager = {}
+
+---@param opts CodeCompanionDap.ScratchBufManager.InitOpts
+---@return CodeCompanionDap.ScratchBufManager
+function ScratchBufManager.new(opts)
+  opts = vim.tbl_deep_extend("force", {
+    session_to_buf = {},
+    bufname_prefix = vim.trim(opts.bufname_prefix or "dap_scratch_buf"),
+    listed = false,
+    ref_added = {},
+    prefix = [[This is a dummy buffer for data handling.
+The user WILL NOT see this buffer.
+DO NOT MENTION THE PATH OR THE NAME OF THIS BUFFER TO THE USER.
+ONLY USE THE INFORMATION FROM THIS BUFFER TO ASSIST YOUR TASK.
+]],
+  }, opts or {})
+
+  opts.prefix = vim.trim(opts.prefix)
+  return setmetatable(opts, { __index = ScratchBufManager })
+end
+
+---Returns the bufname without the cwd.
+---This can be used as a more readable alternative to `nvim_buf_get_name` in UI elements.
+---@param session dap.Session
+---@return string
+function ScratchBufManager:get_readable_bufname(session)
+  self:get_bufnr(session)
+  return string.format("%s %d", self.bufname_prefix, session.id)
+end
+
+---@param session dap.Session
+---@return integer
+function ScratchBufManager:get_bufnr(session)
+  if self.session_to_buf[session.id] == nil then
+    local bufnr = vim.api.nvim_create_buf(self.listed, true)
+    self.session_to_buf[session.id] = bufnr
+    vim.api.nvim_buf_set_name(bufnr, self:get_readable_bufname(session))
+  end
+  return self.session_to_buf[session.id]
+end
+
+---@param dap_session dap.Session
+---@param chat CodeCompanion.Chat
+---@param content string[]
+function ScratchBufManager:update(dap_session, chat, content)
+  if content == nil or vim.tbl_isempty(content) then
+    return
+  end
+
+  local bufnr = self:get_bufnr(dap_session)
+  local buf_name = self:get_readable_bufname(dap_session)
+
+  if
+    not vim.iter(chat.refs or {}):any(function(item)
+      return item and item.source == buf_name
+    end)
+  then
+    chat.references:add({
+      bufnr = bufnr,
+      source = buf_name,
+      opts = {
+        watched = true,
+      },
+      id = buf_name,
+    })
+  end
+
+  local inserted_lines = {}
+  if self.prefix then
+    vim.list_extend(inserted_lines, vim.split(self.prefix, "\n"))
+  end
+  vim.list_extend(inserted_lines, content)
+  vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, inserted_lines)
+end
+
+return ScratchBufManager

--- a/lua/codecompanion/_extensions/dap/tools/stackTrace.lua
+++ b/lua/codecompanion/_extensions/dap/tools/stackTrace.lua
@@ -41,6 +41,7 @@ Empty results indicates that the results are unchanged.
               description = "The maximum number of frames to return. If omitted, all frames are returned.",
             },
           },
+          required = { "threadId" },
         },
       },
     },

--- a/lua/codecompanion/_extensions/dap/tools/stepInTargets.lua
+++ b/lua/codecompanion/_extensions/dap/tools/stepInTargets.lua
@@ -18,6 +18,8 @@ return function(opts)
         name = tool_name,
         description = [[
 The request retrieves possible step-in targets for the current DAP session.
+When you need to investigate the behaviour of a particular symbol (function, class, etc.),
+you may use this tool to find out whether you can step into it's implementation.
 ]],
         parameters = {
           type = "object",

--- a/lua/codecompanion/_extensions/dap/tools/stepping.lua
+++ b/lua/codecompanion/_extensions/dap/tools/stepping.lua
@@ -17,7 +17,7 @@ return function(opts)
         description = [[
 The request provides stepping functionalities for the current DAP session.
 Each `stepping` call should be followed by a `stackTrace` call using the current `threadId` to verify whether the stepping worked as intended.
-Try to call `stackTrace` in the same response as the `stepping` call.
+The `stackTrace` call should be in the same request as the `stepping` call if possible.
 ]],
         parameters = {
           type = "object",

--- a/lua/codecompanion/_extensions/dap/tools/stepping.lua
+++ b/lua/codecompanion/_extensions/dap/tools/stepping.lua
@@ -16,6 +16,8 @@ return function(opts)
         name = tool_name,
         description = [[
 The request provides stepping functionalities for the current DAP session.
+Each `stepping` call should be followed by a `stackTrace` call using the current `threadId` to verify whether the stepping worked as intended.
+Try to call `stackTrace` in the same response as the `stepping` call.
 ]],
         parameters = {
           type = "object",


### PR DESCRIPTION
This utilises the [codecompanion buffer watcher](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/strategies/chat/watchers.lua) to store DAP results in an unlisted scratch buffer.

The watcher will automatically send a diff of the result to the LLM instead of sending the full result. It'll save some tokens as the DAP session gets more complex.